### PR TITLE
Configure GitHub Pages deployment

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -1,0 +1,37 @@
+name: Deploy static site to Pages
+
+on:
+  push:
+    branches: ["main"]
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+concurrency:
+  group: "pages"
+  cancel-in-progress: true
+
+jobs:
+  deploy:
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Setup Pages
+        uses: actions/configure-pages@v3
+
+      - name: Upload static site
+        uses: actions/upload-pages-artifact@v2
+        with:
+          path: ./
+
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v2

--- a/README.md
+++ b/README.md
@@ -2,6 +2,16 @@
 
 Eine kleine HTML/CSS-Screensaver-Seite mit Riverty-Logos.
 
+## Online-Version
+
+Sobald die GitHub-Pages-Bereitstellung (siehe `.github/workflows/pages.yml`) einmal erfolgreich durchgelaufen ist, steht der Screensaver öffentlich unter
+
+```
+https://<dein-github-benutzername>.github.io/screensaver/
+```
+
+zur Verfügung. Öffne die URL einfach in einem aktuellen Browser (z. B. Chrome, Firefox, Edge oder Safari) und der Screensaver lädt automatisch.
+
 ## Nutzung
 
 1. Lade dieses Repository herunter oder klone es.


### PR DESCRIPTION
## Summary
- add a GitHub Actions workflow that deploys the static site to GitHub Pages
- document the hosted URL and how to open it in a browser in the README

## Testing
- not run (configuration changes only)


------
https://chatgpt.com/codex/tasks/task_e_68dc43e9396c832ba5a79bc8857a0c57