### PR TITLE
Enable GitHub Pages site configuration before deploy

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -28,6 +28,8 @@ jobs:
 
       - name: Setup Pages
         uses: actions/configure-pages@v5
+        with:
+          enablement: enable
 
       - name: Upload static site
         uses: actions/upload-pages-artifact@v4


### PR DESCRIPTION
## Summary
- ensure the Setup Pages step enables the GitHub Pages site before deployment

## Testing
- not run (CI only)


------
https://chatgpt.com/codex/tasks/task_e_68dc49ba220c832b8734ef9ecb3abbdb