### PR TITLE
Update theme palettes to new brand colors

### DIFF
--- a/index.html
+++ b/index.html
@@ -22,26 +22,26 @@
   </script>
   <style>
     :root{
-      --sky-top:#9fbfda;
-      --sky-bottom:#d2e4f0;
-      --water-1:#7fb0c6;
-      --water-2:#5a94ab;
-      --water-3:#366f85;
-      --mote:#0f2a37;
-      --text:#0f2a37;
-      --logo: rgba(15,42,55,.06);
+      --sky-top:#F3F1F0;
+      --sky-bottom:#E4DDD6;
+      --water-1:#86A27B;
+      --water-2:#6F8C64;
+      --water-3:#566F4E;
+      --mote:#6F8C64;
+      --text:#282828;
+      --logo: rgba(134,162,123,.18);
       --transition:.8s ease;
       --bg: linear-gradient(180deg,var(--sky-top),var(--sky-bottom));
     }
     [data-theme="night"]{
-      --sky-top:#0b1d2b;
-      --sky-bottom:#152a37;
-      --water-1:#295268;
-      --water-2:#1f4458;
-      --water-3:#163646;
-      --mote:#e7f0f5;
-      --text:#e7f0f5;
-      --logo: rgba(231,240,245,.10);
+      --sky-top:#282828;
+      --sky-bottom:#686868;
+      --water-1:#4F5E49;
+      --water-2:#3C4A38;
+      --water-3:#2A3527;
+      --mote:#F3F1F0;
+      --text:#F3F1F0;
+      --logo: rgba(243,241,240,.16);
     }
     *{box-sizing:border-box;margin:0;padding:0}
     html,body{height:100%}


### PR DESCRIPTION
## Summary
- replace day theme gradients and accent variables with Haze and Vanguard tones
- update night theme palette to use Charcoal and complementary light accents
- refresh logo accent transparency to match the revised color scheme

## Testing
- no tests were run (not applicable)

------
https://chatgpt.com/codex/tasks/task_e_68de90781fdc832b84ee767829c464b1