### PR TITLE
Align canvas palette with Vanguard and Ember tones

### DIFF
--- a/index.html
+++ b/index.html
@@ -27,7 +27,7 @@
       --water-1:#86A27B;
       --water-2:#6F8C64;
       --water-3:#566F4E;
-      --mote:#6F8C64;
+      --mote:#F3F1F0;
       --text:#282828;
       --logo: rgba(134,162,123,.18);
       --transition:.8s ease;
@@ -39,7 +39,7 @@
       --water-1:#4F5E49;
       --water-2:#3C4A38;
       --water-3:#2A3527;
-      --mote:#F3F1F0;
+      --mote:#F49B97;
       --text:#F3F1F0;
       --logo: rgba(243,241,240,.16);
     }
@@ -63,7 +63,7 @@
   </main>
   <script>
     (function(){
-      var root=document.documentElement, lat=48.2082, lon=16.3738, ZEN=90.833, TW=45, TEMP=0;
+      var root=document.documentElement, lat=48.2082, lon=16.3738, ZEN=90.833, TW=45;
       function dayOfYear(d){var s=new Date(d.getFullYear(),0,0);return Math.floor((d-s+(s.getTimezoneOffset()-d.getTimezoneOffset())*6e4)/864e5)}
       function norm(x,m){return (x%m+m)%m}
       function sTimes(d){var N=dayOfYear(d), lh=lon/15, rad=Math.PI/180, tz=-d.getTimezoneOffset()/60;
@@ -75,50 +75,106 @@
       var DPR=Math.min(window.devicePixelRatio||1,1.5), w=0,h=0, now=0, last=performance.now();
       function rs(){w=canvas.width=Math.floor(innerWidth*DPR);h=canvas.height=Math.floor(innerHeight*DPR)} rs(); addEventListener('resize',rs);
       function mix(a,b,t){return a+(b-a)*t}
-      function HSL(hh,ss,ll,a){return 'hsla('+hh+','+ss+'%,'+ll+'%,'+a+')'}
+      function hexToRgb(hex){
+        var h=hex.replace('#','').trim();
+        if(h.length===3){h=h.split('').map(function(ch){return ch+ch}).join('')}
+        if(h.length!==6)return {r:0,g:0,b:0};
+        return {r:parseInt(h.slice(0,2),16),g:parseInt(h.slice(2,4),16),b:parseInt(h.slice(4,6),16)}
+      }
+      function parseColor(value){
+        if(!value)return {r:0,g:0,b:0};
+        var v=value.trim();
+        if(!v)return {r:0,g:0,b:0};
+        if(v[0]==='#') return hexToRgb(v);
+        var match=v.match(/rgba?\(([^)]+)\)/i);
+        if(match){
+          var parts=match[1].split(',');
+          return {r:parseFloat(parts[0]),g:parseFloat(parts[1]),b:parseFloat(parts[2])}
+        }
+        return {r:0,g:0,b:0}
+      }
+      function mixRgb(a,b,t){
+        return {r:Math.round(mix(a.r,b.r,t)),g:Math.round(mix(a.g,b.g,t)),b:Math.round(mix(a.b,b.b,t))}
+      }
+      function rgba(rgb,a){return 'rgba('+Math.round(rgb.r)+','+Math.round(rgb.g)+','+Math.round(rgb.b)+','+a+')'}
+      var COLORS={
+        vanguardLight:hexToRgb('#86A27B'),
+        vanguardMid:hexToRgb('#6F8C64'),
+        vanguardDeep:hexToRgb('#527A42'),
+        charcoal:hexToRgb('#282828'),
+        ember:hexToRgb('#F49B97'),
+        haze:hexToRgb('#F3F1F0')
+      };
+      var waveDayPalette=[
+        mixRgb(COLORS.haze,COLORS.vanguardLight,.25),
+        mixRgb(COLORS.vanguardLight,COLORS.vanguardMid,.5),
+        COLORS.vanguardDeep
+      ];
+      var waveNightPalette=waveDayPalette.map(function(color,idx){
+        return mixRgb(color,COLORS.charcoal,.55+idx*.12)
+      });
+      var emberSoft=mixRgb(COLORS.haze,COLORS.ember,.35);
+      var currentTheme=root.getAttribute('data-theme')||'day';
+      var moteRgb={r:COLORS.haze.r,g:COLORS.haze.g,b:COLORS.haze.b};
+      function refreshThemeColors(){
+        var style=getComputedStyle(root);
+        var moteValue=style.getPropertyValue('--mote');
+        if(moteValue){
+          moteRgb=parseColor(moteValue);
+        }
+      }
       var reduce=matchMedia&&matchMedia('(prefers-reduced-motion: reduce)').matches;
       var waves=[], motes=[], stars=[];
       function init(){
         waves=[
-          {amp:.042,len:1.2,spd:.018,hueD:0,a:.20,blur:.7},
-          {amp:.028,len:2.1,spd:.012,hueD:-6,a:.18,blur:.4},
-          {amp:.018,len:3.2,spd:.009,hueD:-12,a:.14,blur:0}
+          {amp:.042,len:1.2,spd:.018,color:0,a:.20,blur:.7},
+          {amp:.028,len:2.1,spd:.012,color:1,a:.18,blur:.4},
+          {amp:.018,len:3.2,spd:.009,color:2,a:.14,blur:0}
         ];
         var mN=reduce?24:42; motes=[]; for(var i=0;i<mN;i++){motes.push({x:Math.random()*w,y:Math.random()*h*0.8+0.1*h,r:(Math.random()*2+1)*DPR,p:Math.random()*Math.PI*2,s:(Math.random()*0.18+0.06)*(reduce?.5:1)})}
         var sN=reduce?80:150; stars=[]; for(var j=0;j<sN;j++){stars.push({x:Math.random()*w,y:Math.random()*h*0.55,p:Math.random()*Math.PI*2,r:(Math.random()*1.2+.2)*DPR})}
       }
       init();
+      refreshThemeColors();
       var blend=0, sr=0, ss=0;
       function updateBlend(){
         var d=new Date(), t=sTimes(d); sr=t.sr; ss=t.ss; var m=d.getHours()*60+d.getMinutes();
         if(m<sr-TW||m>ss+TW) blend=1; else if(m>sr+TW&&m<ss-TW) blend=0; else if(m>=sr-TW&&m<=sr+TW) blend=1-smooth(sr-TW,sr+TW,m); else if(m>=ss-TW&&m<=ss+TW) blend=smooth(ss-TW,ss+TW,m);
         var theme=blend>=.5?'night':'day'; if(root.getAttribute('data-theme')!==theme) root.setAttribute('data-theme',theme);
+        if(currentTheme!==theme){
+          currentTheme=theme;
+          refreshThemeColors();
+        }
       }
       updateBlend();
       setInterval(updateBlend,5*60*1000);
       document.addEventListener('visibilitychange',function(){if(!document.hidden) updateBlend()});
       function drawWaves(t){
         var k=blend;
-        var hueDay=195+(-10*TEMP), hueNight=210+(-6*TEMP);
-        var baseHue=mix(hueDay,hueNight,k);
         var baseY=h*mix(.62,.58,k);
         for(var i=0;i<waves.length;i++){
-          var W=waves[i]; var amp=W.amp*h*mix(1,1.06,k); var len=W.len*220; var phase=t*W.spd*(reduce?.5:1)+i*0.5; var hue=baseHue+W.hueD;
+          var W=waves[i]; var amp=W.amp*h*mix(1,1.06,k); var len=W.len*220; var phase=t*W.spd*(reduce?.5:1)+i*0.5;
+          var dayColor=waveDayPalette[W.color];
+          var nightColor=waveNightPalette[W.color];
+          var rgb=mixRgb(dayColor,nightColor,k);
           if(W.blur) ctx.filter='blur('+W.blur+'px)'; else ctx.filter='none';
           ctx.beginPath(); ctx.moveTo(0,h);
           for(var x=0;x<=w;x+=2*DPR){ var y=baseY+Math.sin((x/len)+phase)*amp+Math.cos((x/(len*2))-phase*.7)*amp*.45; ctx.lineTo(x,y); }
-          ctx.lineTo(w,h); ctx.closePath(); ctx.fillStyle=HSL(hue, 44, mix(50,41,k), W.a); ctx.fill();
+          ctx.lineTo(w,h); ctx.closePath(); ctx.fillStyle=rgba(rgb,W.a); ctx.fill();
         }
         ctx.filter='none';
       }
       function drawMotes(dt){
-        var k=blend; ctx.globalCompositeOperation='lighter'; ctx.fillStyle=k? 'rgba(255,255,255,'+mix(.02,.09,k)+')':'rgba(15,42,55,.06)';
+        var k=blend; ctx.globalCompositeOperation='lighter';
+        var alpha=mix(.05,.16,k);
+        ctx.fillStyle=rgba(moteRgb,alpha);
         for(var i=0;i<motes.length;i++){var m=motes[i]; m.p+=(m.s*0.5)*(reduce?.5:1); m.x+=Math.cos(m.p)*m.s*10; m.y+=Math.sin(m.p*0.7)*m.s*8; if(m.x<-20||m.x>w+20||m.y<-20||m.y>h*0.92){m.x=Math.random()*w; m.y=h*0.15+Math.random()*h*0.7; m.p=Math.random()*Math.PI*2} ctx.beginPath(); ctx.arc(m.x,m.y,m.r,0,6.283); ctx.fill(); }
         ctx.globalCompositeOperation='source-over';
       }
       function drawStars(t){
         var k=Math.min(1,Math.max(0,blend)); if(k<.02) return; var aBase=.15+.65*k;
-        for(var i=0;i<stars.length;i++){var s=stars[i]; var tw=.5+.5*Math.sin(t*.22+s.p*3.1); ctx.fillStyle='rgba(255,255,255,'+(aBase*tw)+')'; ctx.fillRect(s.x,s.y,s.r,s.r); }
+        var emberGlow=mixRgb(emberSoft,COLORS.ember,k);
+        for(var i=0;i<stars.length;i++){var s=stars[i]; var tw=.5+.5*Math.sin(t*.22+s.p*3.1); ctx.fillStyle=rgba(emberGlow,aBase*tw); ctx.fillRect(s.x,s.y,s.r,s.r); }
       }
       var idleTimer=null, idle=false; function setIdle(v){if(idle===v)return; idle=v; document.body.classList.toggle('idle',idle)} function resetIdle(){setIdle(false); clearTimeout(idleTimer); idleTimer=setTimeout(function(){setIdle(true)},1500)} ['mousemove','touchstart','keydown'].forEach(function(ev){document.addEventListener(ev,resetIdle,{passive:true})}); resetIdle();
       function frame(t){ if(document.hidden){last=t; requestAnimationFrame(frame); return} var dt=(t-last)/1000; last=t; now+=dt; ctx.clearRect(0,0,w,h); drawStars(now); drawWaves(now); drawMotes(dt); requestAnimationFrame(frame) }


### PR DESCRIPTION
## Summary
- replace the dynamic HSL wave hues with Vanguard-inspired palettes and helper utilities
- drive mote colors from CSS variables and update the day/night palette
- tint nighttime stars with Ember tones and refresh theme caches when the mode flips

## Testing
- Manual visual verification in browser

------
https://chatgpt.com/codex/tasks/task_e_68de911ffc18832b8044771fe926260d