### PR TITLE
Clarify GitHub Pages deployment instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,9 @@ Eine kleine HTML/CSS-Screensaver-Seite
 
 ## Online-Version
 
-Sobald die GitHub-Pages-Bereitstellung (siehe `.github/workflows/pages.yml`) einmal erfolgreich durchgelaufen ist, steht der Screensaver öffentlich unter
+Dieses Repository enthält einen GitHub-Actions-Workflow unter `.github/workflows/pages.yml`, der das Projekt nach jedem Push auf den Branch `main` oder `work` automatisch zu GitHub Pages deployt. Aktiviere dazu GitHub Pages in den Repository-Einstellungen („Settings → Pages“) und wähle als Source die Option „GitHub Actions“.
+
+Sobald der Workflow einmal erfolgreich durchgelaufen ist, steht der Screensaver öffentlich unter
 
 ```
 https://<dein-github-benutzername>.github.io/screensaver/


### PR DESCRIPTION
## Summary
- explain how the existing GitHub Pages workflow deploys the site and which branches trigger it
- add a short checklist for enabling GitHub Pages via the GitHub Actions option in the repository settings

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68ded559822c832b8effaf6362e6f2b9