### PR TITLE
Adjust bird animation to start offscreen

### DIFF
--- a/index.html
+++ b/index.html
@@ -112,7 +112,10 @@
     .flock.mid   { top:16vh; animation-duration:75s }   /* mittel */
     .flock.near  { top:22vh; animation-duration:60s }   /* dunkel */
 
-    @keyframes fly{ from{ transform:translateX(0) } to{ transform:translateX(-60%) } }
+    @keyframes fly{
+      from{ transform:translateX(70%) }
+      to  { transform:translateX(-90%) }
+    }
 
     .flock svg{ position:absolute; width:28px; height:14px; }
     .flock.far  svg{ fill:var(--charcoal-25) }


### PR DESCRIPTION
## Summary
- update the bird flock animation so the group enters from the right and exits off the left

## Testing
- no tests were run

------
https://chatgpt.com/codex/tasks/task_e_68dedc8482b0832bbd37941c9524360a