### PR TITLE
Add GitHub Pages deployment workflow

### DIFF
--- a/.github/workflows/deploy-pages.yml
+++ b/.github/workflows/deploy-pages.yml
@@ -1,0 +1,44 @@
+name: Deploy to GitHub Pages
+
+on:
+  push:
+    branches:
+      - main
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+concurrency:
+  group: "pages"
+  cancel-in-progress: false
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Prepare site content
+        run: |
+          mkdir -p public
+          rsync -a --delete --exclude '.git' --exclude '.github' --exclude 'public' ./ public/
+
+      - name: Upload artifact
+        uses: actions/upload-pages-artifact@v3
+        with:
+          path: public
+
+  deploy:
+    runs-on: ubuntu-latest
+    needs: build
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    steps:
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v4

--- a/README.md
+++ b/README.md
@@ -4,13 +4,17 @@ Eine kleine HTML/CSS-Screensaver-Seite
 
 ## Online-Version
 
-Dieses Repository enthält einen GitHub-Actions-Workflow unter `.github/workflows/pages.yml`, der das Projekt nach jedem Push auf den Branch `main` oder `work` automatisch zu GitHub Pages deployt. Aktiviere dazu GitHub Pages in den Repository-Einstellungen („Settings → Pages“) und wähle als Source die Option „GitHub Actions“.
+Das Projekt wird mit dem Workflow [`deploy-pages.yml`](.github/workflows/deploy-pages.yml) automatisch nach GitHub Pages veröffentlicht. So richtest du die Online-Version ein:
 
-Sobald der Workflow einmal erfolgreich durchgelaufen ist, steht der Screensaver öffentlich unter
+1. Aktiviere GitHub Pages in den Repository-Einstellungen (`Settings → Pages`) und wähle als Source die Option „GitHub Actions“.
+2. Stelle sicher, dass deine Änderungen auf dem Branch `main` liegen (oder dort hin gemergt werden).
+3. Warte, bis der Workflow in der Actions-Übersicht erfolgreich durchgelaufen ist.
+
+Nach einem erfolgreichen Lauf findest du die Seite unter
 
 ```
 https://<dein-github-benutzername>.github.io/screensaver/
 ```
 
-zur Verfügung. Öffne die URL einfach in einem aktuellen Browser (z. B. Chrome, Firefox, Edge oder Safari) und der Screensaver lädt automatisch.
+Öffne die URL einfach in einem aktuellen Browser (z. B. Chrome, Firefox, Edge oder Safari) und der Screensaver lädt automatisch.
 


### PR DESCRIPTION
## Summary
- add a GitHub Pages deployment workflow that publishes the static site from the main branch
- update the README to document the new workflow and explain how to enable GitHub Pages

## Testing
- not run (static content only)


------
https://chatgpt.com/codex/tasks/task_e_68dede46e048832bb94aafc314af5d95