### PR TITLE
Ensure bird animation durations respect CSS baselines

### DIFF
--- a/index.html
+++ b/index.html
@@ -177,7 +177,7 @@
 
     <!-- Vögel (CHARCOAL) – V-Form -->
     <div class="birds" aria-hidden="true">
-      <div class="flock far" data-duration-min="40" data-duration-max="48">
+      <div class="flock far" data-duration-min="42" data-duration-max="50">
         <svg class="birdV" viewBox="0 0 24 12" aria-hidden="true"><path d="M0,2 L6,10 L12,2 L10,2 L6,7 L2,2 Z"/></svg>
         <svg class="birdV" viewBox="0 0 24 12" aria-hidden="true"><path d="M0,2 L6,10 L12,2 L10,2 L6,7 L2,2 Z"/></svg>
         <svg class="birdV" viewBox="0 0 24 12" aria-hidden="true"><path d="M0,2 L6,10 L12,2 L10,2 L6,7 L2,2 Z"/></svg>
@@ -187,7 +187,7 @@
         <svg class="birdV" viewBox="0 0 24 12" aria-hidden="true"><path d="M0,2 L6,10 L12,2 L10,2 L6,7 L2,2 Z"/></svg>
         <svg class="birdV" viewBox="0 0 24 12" aria-hidden="true"><path d="M0,2 L6,10 L12,2 L10,2 L6,7 L2,2 Z"/></svg>
       </div>
-      <div class="flock mid" data-duration-min="30" data-duration-max="36">
+      <div class="flock mid" data-duration-min="32" data-duration-max="40">
         <svg class="birdV" viewBox="0 0 24 12" aria-hidden="true"><path d="M0,2 L6,10 L12,2 L10,2 L6,7 L2,2 Z"/></svg>
         <svg class="birdV" viewBox="0 0 24 12" aria-hidden="true"><path d="M0,2 L6,10 L12,2 L10,2 L6,7 L2,2 Z"/></svg>
         <svg class="birdV" viewBox="0 0 24 12" aria-hidden="true"><path d="M0,2 L6,10 L12,2 L10,2 L6,7 L2,2 Z"/></svg>
@@ -197,7 +197,7 @@
         <svg class="birdV" viewBox="0 0 24 12" aria-hidden="true"><path d="M0,2 L6,10 L12,2 L10,2 L6,7 L2,2 Z"/></svg>
         <svg class="birdV" viewBox="0 0 24 12" aria-hidden="true"><path d="M0,2 L6,10 L12,2 L10,2 L6,7 L2,2 Z"/></svg>
       </div>
-      <div class="flock near" data-duration-min="24" data-duration-max="30">
+      <div class="flock near" data-duration-min="26" data-duration-max="34">
         <svg class="birdV" viewBox="0 0 24 12" aria-hidden="true"><path d="M0,2 L6,10 L12,2 L10,2 L6,7 L2,2 Z"/></svg>
         <svg class="birdV" viewBox="0 0 24 12" aria-hidden="true"><path d="M0,2 L6,10 L12,2 L10,2 L6,7 L2,2 Z"/></svg>
         <svg class="birdV" viewBox="0 0 24 12" aria-hidden="true"><path d="M0,2 L6,10 L12,2 L10,2 L6,7 L2,2 Z"/></svg>
@@ -245,12 +245,28 @@
   </main>
   <script>
     (function () {
+      const cssBaselines = new Map([
+        ['far', 42],
+        ['mid', 32],
+        ['near', 26],
+      ]);
+
+      const resolveBaseline = (element) => {
+        for (const [key, value] of cssBaselines.entries()) {
+          if (element.classList.contains(key)) {
+            return value;
+          }
+        }
+        return 0;
+      };
+
       const setRandomTiming = (element) => {
         const min = parseFloat(element.dataset.durationMin);
         const max = parseFloat(element.dataset.durationMax);
         const hasValidRange = Number.isFinite(min) && Number.isFinite(max) && max > min;
-        const durationMin = hasValidRange ? min : 18;
-        const durationMax = hasValidRange ? max : 28;
+        const cssBaseline = resolveBaseline(element);
+        const durationMin = Math.max(hasValidRange ? min : 18, cssBaseline);
+        const durationMax = Math.max(hasValidRange ? max : 28, durationMin + 1);
         const duration = durationMin + Math.random() * (durationMax - durationMin);
         const pause = Math.random() * duration;
         element.style.animationDuration = `${duration.toFixed(2)}s`;


### PR DESCRIPTION
## Summary
- raise the random duration ranges for each bird flock to keep minimums at or above their CSS animation durations
- guard the random timing logic so future updates cannot set values below the CSS baselines

## Testing
- Manual check in browser

------
https://chatgpt.com/codex/tasks/task_e_68dee3ea49f0832bbbaf03f918914916