### PR TITLE
Drop JavaScript, animate flocks with pure-CSS pauses

### DIFF
--- a/index.html
+++ b/index.html
@@ -117,13 +117,15 @@
       height:12%; height:12vh; display:block;
       animation:fly 32s linear infinite;
     }
-    .flock.far   { top:10%; top:10vh; animation-duration:50s }   /* hell */
-    .flock.mid   { top:16%; top:16vh; animation-duration:38s }   /* mittel */
-    .flock.near  { top:22%; top:22vh; animation-duration:30s }   /* dunkel */
+    .flock.far   { top:10%; top:10vh; animation-duration:84s }   /* hell */
+    .flock.mid   { top:16%; top:16vh; animation-duration:63s; animation-delay:-21s }   /* mittel */
+    .flock.near  { top:22%; top:22vh; animation-duration:50s; animation-delay:-35s }   /* dunkel */
 
+    /* Schwarm fliegt 0–60 % des Zyklus über den Schirm, ruht 60–100 % offscreen links. */
     @keyframes fly{
-      from{ transform:translateX(70%) }
-      to  { transform:translateX(-90%) }
+      0%   { transform:translateX(70%) }
+      60%  { transform:translateX(-90%) }
+      100% { transform:translateX(-90%) }
     }
 
     .flock svg{ position:absolute; width:28px; height:14px; }
@@ -186,7 +188,7 @@
 
     <!-- Vögel (CHARCOAL) – V-Form -->
     <div class="birds" aria-hidden="true">
-      <div class="flock far" data-duration-min="50" data-duration-max="62">
+      <div class="flock far">
         <svg class="birdV" viewBox="0 0 24 12" aria-hidden="true"><path d="M0,2 L6,10 L12,2 L10,2 L6,7 L2,2 Z"/></svg>
         <svg class="birdV" viewBox="0 0 24 12" aria-hidden="true"><path d="M0,2 L6,10 L12,2 L10,2 L6,7 L2,2 Z"/></svg>
         <svg class="birdV" viewBox="0 0 24 12" aria-hidden="true"><path d="M0,2 L6,10 L12,2 L10,2 L6,7 L2,2 Z"/></svg>
@@ -196,7 +198,7 @@
         <svg class="birdV" viewBox="0 0 24 12" aria-hidden="true"><path d="M0,2 L6,10 L12,2 L10,2 L6,7 L2,2 Z"/></svg>
         <svg class="birdV" viewBox="0 0 24 12" aria-hidden="true"><path d="M0,2 L6,10 L12,2 L10,2 L6,7 L2,2 Z"/></svg>
       </div>
-      <div class="flock mid" data-duration-min="38" data-duration-max="48">
+      <div class="flock mid">
         <svg class="birdV" viewBox="0 0 24 12" aria-hidden="true"><path d="M0,2 L6,10 L12,2 L10,2 L6,7 L2,2 Z"/></svg>
         <svg class="birdV" viewBox="0 0 24 12" aria-hidden="true"><path d="M0,2 L6,10 L12,2 L10,2 L6,7 L2,2 Z"/></svg>
         <svg class="birdV" viewBox="0 0 24 12" aria-hidden="true"><path d="M0,2 L6,10 L12,2 L10,2 L6,7 L2,2 Z"/></svg>
@@ -206,7 +208,7 @@
         <svg class="birdV" viewBox="0 0 24 12" aria-hidden="true"><path d="M0,2 L6,10 L12,2 L10,2 L6,7 L2,2 Z"/></svg>
         <svg class="birdV" viewBox="0 0 24 12" aria-hidden="true"><path d="M0,2 L6,10 L12,2 L10,2 L6,7 L2,2 Z"/></svg>
       </div>
-      <div class="flock near" data-duration-min="30" data-duration-max="40">
+      <div class="flock near">
         <svg class="birdV" viewBox="0 0 24 12" aria-hidden="true"><path d="M0,2 L6,10 L12,2 L10,2 L6,7 L2,2 Z"/></svg>
         <svg class="birdV" viewBox="0 0 24 12" aria-hidden="true"><path d="M0,2 L6,10 L12,2 L10,2 L6,7 L2,2 Z"/></svg>
         <svg class="birdV" viewBox="0 0 24 12" aria-hidden="true"><path d="M0,2 L6,10 L12,2 L10,2 L6,7 L2,2 Z"/></svg>
@@ -252,71 +254,5 @@
       <img src="https://cdn.riverty.design/logo/riverty-logomark-light.svg" alt="">
     </div>
   </main>
-  <script>
-    (function () {
-      const cssBaselines = new Map([
-        ['far', 50],
-        ['mid', 38],
-        ['near', 30],
-      ]);
-
-      const resolveBaseline = (element) => {
-        for (const [key, value] of cssBaselines.entries()) {
-          if (element.classList.contains(key)) {
-            return value;
-          }
-        }
-        return 0;
-      };
-
-      const setRandomTiming = (element) => {
-        const min = parseFloat(element.dataset.durationMin);
-        const max = parseFloat(element.dataset.durationMax);
-        const hasValidRange = Number.isFinite(min) && Number.isFinite(max) && max > min;
-        const cssBaseline = resolveBaseline(element);
-        const durationMin = Math.max(hasValidRange ? min : 18, cssBaseline);
-        const durationMax = Math.max(hasValidRange ? max : 28, durationMin + 1);
-        const duration = durationMin + Math.random() * (durationMax - durationMin);
-        const pause = Math.random() * duration;
-        return { duration, pause };
-      };
-
-      const pendingTimeouts = new WeakMap();
-
-      const restartAnimation = (flock) => {
-        const timeoutId = pendingTimeouts.get(flock);
-        if (timeoutId) {
-          clearTimeout(timeoutId);
-          pendingTimeouts.delete(flock);
-        }
-
-        const { duration, pause } = setRandomTiming(flock);
-
-        flock.style.animation = 'none';
-        flock.style.transform = 'translateX(70%)';
-        void flock.offsetWidth;
-
-        const start = () => {
-          flock.style.animation = `fly ${duration.toFixed(2)}s linear 0s infinite`;
-          pendingTimeouts.delete(flock);
-        };
-
-        if (pause > 0) {
-          const id = setTimeout(start, pause * 1000);
-          pendingTimeouts.set(flock, id);
-        } else {
-          start();
-        }
-      };
-
-      const flocks = document.querySelectorAll('.flock');
-      flocks.forEach((flock) => {
-        restartAnimation(flock);
-        flock.addEventListener('animationiteration', () => {
-          restartAnimation(flock);
-        });
-      });
-    })();
-  </script>
 </body>
 </html>


### PR DESCRIPTION
## Summary

Auf Wunsch (kein JavaScript, „CSS only" zählt) wurde der Screensaver von allen JS-Anteilen befreit:

- Den gesamten `<script>`-Block aus `index.html` entfernt.
- Die JS-only Attribute `data-duration-min` / `data-duration-max` an den drei `.flock`-DIVs entfernt.

Damit der frühere Eindruck von Flügen mit dazwischenliegenden Pausen (vorher per JS zufällig gesetzt) erhalten bleibt, ist die `fly`-Keyframe-Animation reine CSS:

```css
@keyframes fly{
  0%   { transform:translateX(70%) }   /* offscreen rechts */
  60%  { transform:translateX(-90%) }  /* Flug bis offscreen links */
  100% { transform:translateX(-90%) }  /* Pause offscreen */
}
```

- 0–60 % des Zyklus: sichtbarer Flug von rechts nach links.
- 60–100 %: Schwarm parkt offscreen links.
- Der Sprung von `-90%` zurück auf `70%` zwischen Iterationen ist unsichtbar, weil beide Positionen außerhalb des Viewports liegen (keine Interpolation zwischen Iterationen).

Die `animation-duration` pro Schwarm wurde so skaliert, dass die effektive Flugdauer in etwa den vorherigen Werten entspricht (≈ 50 s / 38 s / 30 s für `far` / `mid` / `near`). Negative `animation-delay`-Werte verschieben die Anfangsphasen, sodass die drei Schwärme beim Laden bereits in unterschiedlichen Phasen sind (einer startet rechts, einer fliegt schon, einer ruht).

`prefers-reduced-motion: reduce` greift weiterhin (`.cloud, .hill, .flock { animation: none !important; }`).

## Test plan
- [ ] `index.html` lokal im Browser öffnen — alle drei Schwärme bewegen sich, keine Konsolen-Fehler.
- [ ] Mit DevTools-Suche bestätigen, dass weder `<script>` noch `onclick`/`onload` in der Datei vorkommen.
- [ ] Mit aktivem „prefers-reduced-motion: reduce" bleiben Vögel/Wolken/Hügel statisch.

---
_Generated by [Claude Code](https://claude.ai/code/session_01VmrKRfbpxhJS6vcsYFfqD4)_