### PR TITLE
Tighten compositing hints and dedupe identical keyframes

### DIFF
--- a/index.html
+++ b/index.html
@@ -63,6 +63,7 @@
       height:42%;
       height:42vh;
       pointer-events:none;
+      contain:layout paint;
     }
     .cloud{
       position:absolute; left:0; top:0;
@@ -70,19 +71,15 @@
       will-change:transform;
       filter:blur(10px);
       opacity:.9;
-      backface-visibility:hidden;
-      transform:translateZ(0);
     }
     .cloud svg{width:50%; height:100%; flex:0 0 50%; shape-rendering:geometricPrecision}
     .cloud .shape{fill: currentColor}
 
-    .c1{ color:var(--haze-50); height:18%; height:18vh; top:10%; top:10vh; filter:blur(14px); animation:drift1 110s linear infinite }
-    .c2{ color:var(--haze-80); height:16%; height:16vh; top:16%; top:16vh; filter:blur(12px); animation:drift2 85s  linear infinite reverse }
-    .c3{ color:var(--haze-100);height:14%; height:14vh; top:22%; top:22vh; filter:blur(10px); animation:drift3 70s  linear infinite }
+    .c1{ color:var(--haze-50); height:18%; height:18vh; top:10%; top:10vh; filter:blur(14px); animation:drift 110s linear infinite }
+    .c2{ color:var(--haze-80); height:16%; height:16vh; top:16%; top:16vh; filter:blur(12px); animation:drift 85s  linear infinite reverse }
+    .c3{ color:var(--haze-100);height:14%; height:14vh; top:22%; top:22vh; filter:blur(10px); animation:drift 70s  linear infinite }
 
-    @keyframes drift1{from{transform:translateX(0)} to{transform:translateX(-50%)}}
-    @keyframes drift2{from{transform:translateX(0)} to{transform:translateX(-50%)}}
-    @keyframes drift3{from{transform:translateX(0)} to{transform:translateX(-50%)}}
+    @keyframes drift{from{transform:translateX(0)} to{transform:translateX(-50%)}}
 
     /* ========= 4) Wiese (VANGUARD) ========= */
     .meadow-base{
@@ -93,28 +90,26 @@
         var(--vanguard-100) 100%
       );
     }
-    .hills{ position:absolute; left:0; right:0; bottom:0; height:60%; height:60vh; pointer-events:none }
+    .hills{ position:absolute; left:0; right:0; bottom:0; height:60%; height:60vh; pointer-events:none; contain:layout paint }
     .hill{
       position:absolute; left:0; bottom:0;
       width:200%; display:flex; will-change:transform;
-      backface-visibility:hidden; transform:translateZ(0);
     }
     .hill svg{width:50%; height:100%; flex:0 0 50%; shape-rendering:geometricPrecision}
     .hill .shape{fill: currentColor}
 
-    .h1{ color:var(--vanguard-30); height:42%; height:42vh; bottom:18%; bottom:18vh; opacity:.34; animation:hill1 38s linear infinite }
-    .h2{ color:var(--vanguard-70); height:48%; height:48vh; bottom:10%; bottom:10vh; opacity:.30; animation:hill2 52s linear infinite reverse }
-    .h3{ color:var(--vanguard-100);height:60%; height:60vh; bottom: 0;  opacity:.26; animation:hill3 70s linear infinite }
+    .h1{ color:var(--vanguard-30); height:42%; height:42vh; bottom:18%; bottom:18vh; opacity:.34; animation:hill 38s linear infinite }
+    .h2{ color:var(--vanguard-70); height:48%; height:48vh; bottom:10%; bottom:10vh; opacity:.30; animation:hill 52s linear infinite reverse }
+    .h3{ color:var(--vanguard-100);height:60%; height:60vh; bottom: 0;  opacity:.26; animation:hill 70s linear infinite }
 
-    @keyframes hill1{from{transform:translateX(0)} to{transform:translateX(-50%)}}
-    @keyframes hill2{from{transform:translateX(0)} to{transform:translateX(-50%)}}
-    @keyframes hill3{from{transform:translateX(0)} to{transform:translateX(-50%)}}
+    @keyframes hill{from{transform:translateX(0)} to{transform:translateX(-50%)}}
 
     /* ========= 5) Vögel (CHARCOAL) – „V“-Silhouetten & V-Formation ========= */
-    .birds{ position:absolute; inset:0; pointer-events:none }
+    .birds{ position:absolute; inset:0; pointer-events:none; contain:layout paint }
     .flock{
       position:absolute; left:-40%; width:200%;
       height:12%; height:12vh; display:block;
+      will-change:transform;
       animation:fly 32s linear infinite;
     }
     .flock.far   { top:10%; top:10vh; animation-duration:84s }   /* hell */


### PR DESCRIPTION
## Summary

Performance- und Aufräum-Pass am Screensaver — rein CSS, keine optische Änderung.

### Performance
- **Sechs identische `@keyframes` zu zwei zusammengefasst:** `drift1/2/3` → `drift`, `hill1/2/3` → `hill`. Die Bodies waren byteweise gleich; sechs separate Regeln waren reine Parser-/Stylesheet-Bloat.
- **`will-change:transform` auf `.flock` ergänzt.** `.cloud` und `.hill` hatten den GPU-Hint schon, die Schwärme bisher nicht — sie animieren aber genauso nur `transform`, gehören also auf einen eigenen Compositor-Layer.
- **`contain:layout paint` auf den drei Animations-Containern** `.clouds`, `.hills`, `.birds`. Jeder hat eine feste Größe und nur absolut positionierte animierte Kinder, deren Paint innerhalb der Container-Box bleibt (cloud-Blur-Halos geprüft: `.c1` blur(14px), Unterkante ≈ 29.5vh, `.clouds` ist 42vh hoch — keine Clipping-Effekte). Paint-Containment macht jeden Teilbaum zu einer eigenen Paint-Root.

### Aufräumen
- **`transform:translateZ(0)` und `backface-visibility:hidden` aus `.cloud` und `.hill` entfernt.** Beide sind veraltete GPU-Promotion-Hacks und parallel zu `will-change:transform` redundant. Das statische `translateZ(0)` wird sowieso von der animierten `transform`-Property überschrieben; 3D-Transforms (für die backface-visibility relevant wäre) gibt es nicht.

### Was bleibt unverändert
- Kein JavaScript hinzugefügt — bleibt rein CSS.
- `prefers-reduced-motion: reduce` deaktiviert weiterhin alle Animationen über die bestehende Media Query.
- Farbpalette, Geometrie, Z-Index-Stacking, Timings, V-Formation — alles identisch.

## Test plan
- [ ] `index.html` lokal im Browser öffnen — Wolken driften, Hügel scrollen, Schwärme fliegen, Logo zentriert.
- [ ] In den DevTools im Layers-Panel prüfen, dass `.cloud`, `.hill` und `.flock` jeweils einen eigenen Compositor-Layer haben.
- [ ] Mit aktivem „prefers-reduced-motion: reduce" stehen Wolken/Hügel/Vögel still.
- [ ] Optisch keine sichtbare Änderung gegen `main` vor diesem PR.

---
_Generated by [Claude Code](https://claude.ai/code/session_01VmrKRfbpxhJS6vcsYFfqD4)_